### PR TITLE
#17 Set unique property on 'name' column in fish table

### DIFF
--- a/migrations/20181128102151_fish.js
+++ b/migrations/20181128102151_fish.js
@@ -1,7 +1,7 @@
 exports.up = knex =>
   knex.schema.createTable('fish', t => {
     t.increments('id').primary()
-    t.string('name')
+    t.string('name').unique()
     t.timestamps(true, true)
   })
 


### PR DESCRIPTION
Changed the 'name' column within the fish table to be unique to avoid the possibility of the same named fish being added and breaking the routing.