### PR TITLE
25 update client routes

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -15,7 +15,7 @@ class App extends React.Component {
           <Container style={{marginTop: 75}}>
             <Switch>
               <Route exact path='/' component={FishList} />
-              <Route path='/fish/:name' component={FishDetails} />
+              <Route path='/fish/:id' component={FishDetails} />
             </Switch>
           </Container>
         </React.Fragment>

--- a/client/components/Fish.jsx
+++ b/client/components/Fish.jsx
@@ -3,6 +3,6 @@ import {Link} from 'react-router-dom'
 
 export default function Fish (props) {
   return (
-    <li><Link to={`/fish/${props.fishData.name}`}>{props.fishData.name}</Link></li>
+    <li><Link to={`/fish/${props.fishData.id}`}>{props.fishData.name}</Link></li>
   )
 }

--- a/client/components/FishDetails.jsx
+++ b/client/components/FishDetails.jsx
@@ -3,7 +3,6 @@ import {Container, Grid, Icon, Image, Header, Divider, Button, Placeholder} from
 import {Link} from 'react-router-dom'
 
 const FishDetails = ({match}) => {
-
   const name = (match.params.name)
 
   return (

--- a/client/components/FishDetails.jsx
+++ b/client/components/FishDetails.jsx
@@ -1,10 +1,8 @@
 import React from 'react'
 import {Container, Grid, Icon, Image, Header, Divider, Button, Placeholder} from 'semantic-ui-react'
-import {Link} from 'react-router-dom'
+// import {Link} from 'react-router-dom'
 
-const FishDetails = ({match}) => {
-  const name = (match.params.name)
-
+const FishDetails = () => {
   return (
     <div>
       <Container>
@@ -13,7 +11,7 @@ const FishDetails = ({match}) => {
             <Icon onClick={() => history.back()} color='green' name='arrow circle left' size='huge' />
           </Grid.Column>
           <Grid.Column>
-            <Header size='huge' textAlign='center'>{name}</Header> {/* This is where the props for the fish name will go */}
+            <Header size='huge' textAlign='center'>Lorem</Header> {/* This is where the props for the fish name will go */}
           </Grid.Column>
           <Grid.Column>
             <Image circular align='right' size='tiny' src='https://placekitten.com/200/200'></Image> {/* This is where the props for the image will go */}


### PR DESCRIPTION
Client routes have now been updated from /fish/:fishname to /fish/:id so that more than one fish with the same name can be added to the database if the catch method is different and still work with client routing.