### PR TITLE
Did the #29 changed on this branch as it had the levels table.

### DIFF
--- a/migrations/20181128102151_fish.js
+++ b/migrations/20181128102151_fish.js
@@ -3,6 +3,7 @@ exports.up = knex =>
     t.increments('id').primary()
     t.string('name')
     t.integer('method_id').references('methods.id')
+    t.integer('level_id').references('levels.id')
     t.timestamps(true, true)
   })
 


### PR DESCRIPTION
Added connection for levels.id to fish table.
Do we need to input the data of method.id and level.id fields to the fish table? (We may have missed this step for methods ticket as well)