### PR TITLE
Fix id bug

### DIFF
--- a/client/actions/fish.js
+++ b/client/actions/fish.js
@@ -68,7 +68,7 @@ export function getFish () {
 
     request
       .get('/api/v1/fish')
-      .then(res => dispatch(getFishSuccess(res.body)))
+      .then(res => dispatch(getFishSuccess(res.body.fish)))
       .catch(err => dispatch(getFishError(err.message)))
   }
 }

--- a/server/db/fish.js
+++ b/server/db/fish.js
@@ -3,7 +3,16 @@ const connection = require('./')
 function get (db = connection) {
   return db('fish')
     .join('levels', 'fish.level_id', '=', 'levels.id')
-    .select()
+    .select(
+      'fish.id as id',
+      'fish.name as name',
+      'color',
+      'level',
+      'level_id',
+      'method_id',
+      'fish.created_at',
+      'fish.updated_at'
+    )
 }
 
 function createFish (

--- a/server/routes/fish.js
+++ b/server/routes/fish.js
@@ -7,7 +7,15 @@ const fishDetails = require('../db/fishDetails')
 const router = express.Router()
 
 router.get('/', (req, res) => {
-  fish.get().then(fish => res.status(200).json(fish))
+  fish.get()
+    .then(fish => res.status(200).json({
+      ok: true,
+      fish
+    }))
+    .catch(err => res.status(500).json({
+      ok: false,
+      error: err.message
+    }))
 })
 
 router.get('/:id', (req, res) => {

--- a/tests/client/components/fish.test.js
+++ b/tests/client/components/fish.test.js
@@ -4,7 +4,7 @@ import Fish from '../../../client/components/Fish'
 import {Link} from 'react-router-dom'
 
 test('Fish function should contain fishID and name', () => {
-  const expected = <Link to='/fish/4'>fish</Link>
+  const expected = <Link to='/fish/4' replace={false}>fish</Link>
   const props = {
     fishData: {
       id: 4,
@@ -12,6 +12,6 @@ test('Fish function should contain fishID and name', () => {
     }
   }
   const wrapper = shallow(<Fish {...props}/>)
-  expect(wrapper.containsMatchingElement(expected))
-    .toBeTruthy()
+  const links = wrapper.find({ to: '/fish/4' })
+  expect(links.length).toBe(1)
 })


### PR DESCRIPTION
We inadvertently forgot to specify exactly which `id` field we wanted from which table in this query:

```js
function get (db = connection) {
  return db('fish')
    .join('levels', 'fish.level_id', '=', 'levels.id')
    .select()
}
```

Without using an alias `select('fish.id as id'...)` we were accidentally getting the threat level id instead. Because that got repeated, we had a bunch of fish with the same id. This PR fixes the issue by specifying exactly which fields we want.

closes #99 